### PR TITLE
Log redis entries with logrus

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -69,6 +69,10 @@ by caching exports from poeditor`,
 			logger.Fatal(err)
 		}
 
+		redis.SetLogger(&cache.RedisLogger{
+			Entry: logrus.NewEntry(logger),
+		})
+
 		cli := poedit.NewClient(viper.GetString(confApiToken), http.DefaultClient)
 
 		svc := project.NewService(cli, c)

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -10,6 +10,7 @@ import (
 
 	redisCache "github.com/go-redis/cache/v8"
 	"github.com/go-redis/redis/v8"
+	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 )
@@ -27,6 +28,14 @@ type RedisCache struct {
 type RedisCacheItem struct {
 	Hash string
 	Data []byte
+}
+
+type RedisLogger struct {
+	*logrus.Entry
+}
+
+func (r *RedisLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+	r.WithContext(ctx).Printf(format, v...)
 }
 
 func NewRedisCache(c *redis.Client, ttl time.Duration) *RedisCache {


### PR DESCRIPTION
Wrap a logrus entry in a struct in order to implement redis' own logger interface.

It's only possible to set the "global" logger for redis. You cant include it in the client