### PR TITLE
Don't log client closed connection errors

### DIFF
--- a/internal/rest/v1/project.go
+++ b/internal/rest/v1/project.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -37,6 +39,10 @@ func getProjectLanguage(ctx echo.Context) error {
 		req.Language,
 		"key_value_json",
 	)
+	if errors.Is(err, context.Canceled) {
+		return echo.NewHTTPError(499, "client closed request")
+	}
+
 	if err != nil {
 		switch err.(type) {
 		case *poedit.ErrProjectPermissionDenied:


### PR DESCRIPTION
Don't log context canceled errors as errors, when retrieving translations. It happens, when a client closes a request prematurely