### PR TITLE
Implement if-none-match client side caching

### DIFF
--- a/internal/rest/v1/project.go
+++ b/internal/rest/v1/project.go
@@ -60,6 +60,10 @@ func (h *Handlers) getProjectLanguage(ctx echo.Context, l *logrus.Entry) error {
 		return echo.NewHTTPError(499, "client closed request")
 	}
 
+	if ctx.Request().Header.Get("If-None-Match") == trans.Checksum {
+		return ctx.NoContent(http.StatusNotModified)
+	}
+
 	if err != nil {
 		switch err.(type) {
 		case *poedit.ErrProjectPermissionDenied:


### PR DESCRIPTION
<!-- Describe how this pull request changes the application -->
### What this pull request does

- Return `304 Not Modified` if the checksum of a translation matches the `If-None-Match` header

<!-- Describe the problem or why the feature is necessary -->
### Why is this pull request necessary

- Browsers do not handle etag caching on their own, and have to be directed by the server. This is a proper implementation of clientside caching with etags

<!-- Checklist to help remember things to do before submitting the pull request. Delete items, that don't apply -->
### Checklist

- [x] Commits have been cleaned
- [x] Branch is rebased on top of base branch

### User facing changelog

```release-note
Fix an issue, where the server did not respond with a 304 if the `If-None-Match` header matched the content checksum
```