### PR TITLE
Client package

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,39 +11,47 @@ import (
 	"gopkg.in/resty.v1"
 )
 
+// Client is a client for fetching translations from parrot.
 type Client interface {
+	// GetTranslation returns a map of terms for the given language.
 	GetTranslation(ctx context.Context, language string) (map[string]string, error)
 }
 
+// CachedClientImpl is a client that caches translations in memory.
 type CachedClientImpl struct {
 	httpClient *resty.Client
 	projectID  int
-	cache      map[string]CacheItem
+	cache      map[string]cacheItem
 	mutex      *sync.Mutex
 	ttl        time.Duration
 }
 
+// NewCachedClient creates a new client that caches translations in memory.
 func NewCachedClient(endpoint string, project int, ttl time.Duration) *CachedClientImpl {
 	return &CachedClientImpl{
 		httpClient: resty.New().SetHostURL(endpoint),
 		projectID:  project,
-		cache:      map[string]CacheItem{},
+		cache:      map[string]cacheItem{},
 		mutex:      &sync.Mutex{},
 		ttl:        ttl,
 	}
 }
 
-type CacheItem struct {
+// cacheItem is a single cached translation, as it appears in the cache.
+type cacheItem struct {
 	Etag    string
 	Data    map[string]string
 	Expires time.Time
 }
 
-type Response []struct {
+// response is the response type returned from parrot, with the json format.
+type response []struct {
 	Term       string `json:"term"`
 	Definition string `json:"definition"`
 }
 
+// GetTranslation returns a map of terms for the given language. It will return cached data
+// if it has not expired, otherwise it will fetch the data from the upstream.
 func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) (map[string]string, error) {
 	key := cacheKey(c.projectID, language)
 	// Lock here to avoid multiple concurrent requests to upstream
@@ -54,6 +62,7 @@ func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) 
 		return cached.Data, nil
 	}
 
+	// Fetch from upstream and store in the cache
 	request := c.httpClient.R().
 		SetContext(ctx).
 		SetPathParams(map[string]string{
@@ -61,7 +70,7 @@ func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) 
 			"language": language,
 		}).
 		SetQueryParam("format", "json").
-		SetResult(Response{})
+		SetResult(response{})
 
 	if exists {
 		request = request.SetHeader("If-None-Match", cached.Etag)
@@ -69,13 +78,13 @@ func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) 
 
 	resp, err := request.Get("/v1/project/{project}/language/{language}")
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get translation")
+		return nil, errors.Wrap(err, "Failed to fetch translation")
 	}
 
 	switch resp.StatusCode() {
 	case http.StatusNotModified:
-		// Renew cached item
-		c.cache[key] = CacheItem{
+		// Handle 304 Not Modified by renewing the cached item
+		c.cache[key] = cacheItem{
 			Etag:    cached.Etag,
 			Data:    cached.Data,
 			Expires: time.Now().Add(c.ttl),
@@ -83,13 +92,13 @@ func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) 
 
 		return cached.Data, nil
 	case http.StatusOK:
-		// Cache response
-		data, ok := resp.Result().(*Response)
+		// Handle 200 OK by storing the response in the cache
+		data, ok := resp.Result().(*response)
 		if !ok || data == nil {
 			return nil, errors.Errorf("Failed to parse response: '%s'", data)
 		}
 		result := mapResponse(*data)
-		c.cache[key] = CacheItem{
+		c.cache[key] = cacheItem{
 			Etag:    resp.Header().Get("Etag"),
 			Data:    result,
 			Expires: time.Now().Add(c.ttl),
@@ -105,7 +114,8 @@ func cacheKey(projectID int, language string) string {
 	return "translation:" + strconv.Itoa(projectID) + ":" + language
 }
 
-func mapResponse(resp Response) map[string]string {
+// mapResponse converts the response from parrot into a map of terms.
+func mapResponse(resp response) map[string]string {
 	result := map[string]string{}
 
 	for _, item := range resp {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/resty.v1"
+)
+
+type Client interface {
+	GetTranslation(ctx context.Context, language string) (map[string]string, error)
+}
+
+type CachedClientImpl struct {
+	httpClient *resty.Client
+	projectID  int
+	cache      map[string]CacheItem
+	mutex      *sync.Mutex
+	ttl        time.Duration
+}
+
+func NewCachedClient(endpoint string, project int, ttl time.Duration) *CachedClientImpl {
+	return &CachedClientImpl{
+		httpClient: resty.New().SetHostURL(endpoint),
+		projectID:  project,
+		cache:      map[string]CacheItem{},
+		mutex:      &sync.Mutex{},
+		ttl:        ttl,
+	}
+}
+
+type CacheItem struct {
+	Etag    string
+	Data    map[string]string
+	Expires time.Time
+}
+
+type Response []struct {
+	Term       string `json:"term"`
+	Definition string `json:"definition"`
+}
+
+func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) (map[string]string, error) {
+	key := cacheKey(c.projectID, language)
+	// Lock here to avoid multiple concurrent requests to upstream
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	cached, exists := c.cache[key]
+	if exists && cached.Expires.After(time.Now()) {
+		return cached.Data, nil
+	}
+
+	request := c.httpClient.R().
+		SetContext(ctx).
+		SetPathParams(map[string]string{
+			"project":  strconv.Itoa(c.projectID),
+			"language": language,
+		}).
+		SetQueryParam("format", "json").
+		SetResult(Response{})
+
+	if exists {
+		request = request.SetHeader("If-None-Match", cached.Etag)
+	}
+
+	resp, err := request.Get("/v1/project/{project}/language/{language}")
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get translation")
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusNotModified:
+		// Renew cached item
+		c.cache[key] = CacheItem{
+			Etag:    cached.Etag,
+			Data:    cached.Data,
+			Expires: time.Now().Add(c.ttl),
+		}
+
+		return cached.Data, nil
+	case http.StatusOK:
+		// Cache response
+		data, ok := resp.Result().(*Response)
+		if !ok || data == nil {
+			return nil, errors.Errorf("Failed to parse response: '%s'", data)
+		}
+		result := mapResponse(*data)
+		c.cache[key] = CacheItem{
+			Etag:    resp.Header().Get("Etag"),
+			Data:    result,
+			Expires: time.Now().Add(c.ttl),
+		}
+
+		return result, nil
+	default:
+		return nil, errors.Errorf("Unexpected response code: %d", resp.StatusCode())
+	}
+}
+
+func cacheKey(projectID int, language string) string {
+	return "translation:" + strconv.Itoa(projectID) + ":" + language
+}
+
+func mapResponse(resp Response) map[string]string {
+	result := map[string]string{}
+
+	for _, item := range resp {
+		result[item.Term] = item.Definition
+	}
+
+	return result
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -95,7 +95,7 @@ func (c *CachedClientImpl) GetTranslation(ctx context.Context, language string) 
 		// Handle 200 OK by storing the response in the cache
 		data, ok := resp.Result().(*response)
 		if !ok || data == nil {
-			return nil, errors.Errorf("Failed to parse response: '%s'", data)
+			return nil, errors.Errorf("Failed to parse response: '%s'", resp.Body())
 		}
 		result := mapResponse(*data)
 		c.cache[key] = cacheItem{


### PR DESCRIPTION
<!-- Describe how this pull request changes the application -->
### What this pull request does

- Add a client package for use in backend projects
- Implement client with built-in memory cache, based on a time-to-live and making use of the etag and If-None-Match headers used in the parrot server.

<!-- Describe the problem or why the feature is necessary -->
### Why is this pull request necessary

- Since the handin-exporter project needs access to the language terms, this is a client ready to be included in other go projects, that should take care of providing terms reasonably fast

<!-- Checklist to help remember things to do before submitting the pull request. Delete items, that don't apply -->
### Checklist

- [x] Commits have been cleaned
- [x] Branch is rebased on top of base branch

### User facing changelog

```release-note
Include a client package ready to be imported from `github.com/uniwise/parrot/pkg/client`
```